### PR TITLE
Auth enhancements

### DIFF
--- a/src/backend/src/auth/modules/oauth/dto/oauth.dto.ts
+++ b/src/backend/src/auth/modules/oauth/dto/oauth.dto.ts
@@ -42,3 +42,8 @@ export class OAuthSignUpDto {
 export interface OAuthJwtPayload {
   oAuthUser: OAuthUserDto;
 }
+
+export interface OAuthTempToken {
+  jwt: string;
+  alreadySignedUp: boolean;
+}

--- a/src/backend/src/auth/modules/oauth/oauth.controller.ts
+++ b/src/backend/src/auth/modules/oauth/oauth.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { User } from '../../decorators';
-import { OAuthUserDto, OAuthSignUpDto } from './dto';
+import { OAuthUserDto, OAuthSignUpDto, OAuthTempToken } from './dto';
 import { OAuth2Guard } from './guard';
 import { OauthService } from './oauth.service';
 
@@ -29,9 +29,15 @@ export class OauthController {
 
   @Get('signup-temp-token')
   @UseGuards(OAuth2Guard)
-  async oauthSignUpTempToken(@User() user: OAuthUserDto) {
-    return {
-      jwt: await this.service.signTempToken({ oAuthUser: user }),
-    };
+  async oauthSignUpTempToken(
+    @User() user: OAuthUserDto,
+  ): Promise<OAuthTempToken> {
+    if (await this.service.oauthExistUser(user))
+      return { jwt: '', alreadySignedUp: true };
+    else
+      return {
+        jwt: await this.service.signTempToken({ oAuthUser: user }),
+        alreadySignedUp: false,
+      };
   }
 }

--- a/src/backend/src/auth/modules/oauth/oauth.service.ts
+++ b/src/backend/src/auth/modules/oauth/oauth.service.ts
@@ -39,7 +39,7 @@ export class OauthService {
       where: { oauthId: apiUser.id },
       include: { user: true },
     });
-    if (!authInfo) throw new ForbiddenException('Unknown user');
+    if (!authInfo) throw new ForbiddenException('Unknown user. Sign up first.');
     else return authInfo.user;
   }
 

--- a/src/backend/src/auth/modules/oauth/oauth.service.ts
+++ b/src/backend/src/auth/modules/oauth/oauth.service.ts
@@ -43,6 +43,14 @@ export class OauthService {
     else return authInfo.user;
   }
 
+  async oauthExistUser(apiUser: OAuthUserDto) {
+    const authInfo = await this.db.auth.findUnique({
+      where: { oauthId: apiUser.id },
+      include: { user: true },
+    });
+    return authInfo != null;
+  }
+
   async oauthCreateUser(dto: OAuthSignUpDto) {
     if (!(await this.verifyTempToken(dto.jwt)))
       throw new ForbiddenException('Invalid temp jwt token');

--- a/src/frontend/src/app/app-routing.module.ts
+++ b/src/frontend/src/app/app-routing.module.ts
@@ -7,11 +7,13 @@ import { OauthCallbackComponent } from './auth/oauth/oauth-callback.component';
 import { SignOutComponent } from './auth/signout/signout.component';
 import { InfoComponent } from './auth/info/info.component';
 import { OtpPageComponent } from './auth/two-factors/otp-page/otp-page.component';
+import { IsSignedInGuard } from './auth/jwt/guard/is-signed-in.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: HomeComponent,
+    canActivate: [IsSignedInGuard],
   },
   {
     path: 'auth',

--- a/src/frontend/src/app/auth/jwt/guard/is-signed-in.guard.spec.ts
+++ b/src/frontend/src/app/auth/jwt/guard/is-signed-in.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IsSignedInGuard } from './is-signed-in.guard';
+
+describe('IsSignedInGuard', () => {
+  let guard: IsSignedInGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(IsSignedInGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/auth/jwt/guard/is-signed-in.guard.ts
+++ b/src/frontend/src/app/auth/jwt/guard/is-signed-in.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { JwtService } from '../jwt.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IsSignedInGuard implements CanActivate {
+  constructor(private jwt: JwtService, private _router: Router) {}
+
+  canActivate() {
+    if (this.jwt.username) return true;
+    else {
+      this._router.navigate(['/auth/signin']);
+      return false;
+    }
+  }
+}

--- a/src/frontend/src/app/auth/oauth/dto/auth.dto.ts
+++ b/src/frontend/src/app/auth/oauth/dto/auth.dto.ts
@@ -13,3 +13,8 @@ export interface OAuthUserDto {
 export interface OAuthJwtPayload {
   oAuthUser: OAuthUserDto;
 }
+
+export interface OAuthTempToken {
+  jwt: string;
+  alreadySignedUp: boolean;
+}

--- a/src/frontend/src/app/auth/oauth/oauth.service.ts
+++ b/src/frontend/src/app/auth/oauth/oauth.service.ts
@@ -73,11 +73,7 @@ export class OAuthService {
               replaceUrl: true, // prevent going back to the callback page
             });
           else if (response.alreadySignedUp)
-            this.router.navigate(['/auth/signin'], {
-              state: {
-                error: 'OAuth account already used.',
-              },
-            });
+            this.signin.signInFailure('OAuth account already used');
         },
         error: (err) => console.warn(err),
       });

--- a/src/frontend/src/app/auth/signin/signin.component.html
+++ b/src/frontend/src/app/auth/signin/signin.component.html
@@ -34,8 +34,8 @@
       </button>
     </form>
 
-    <div *ngIf="state.failure" class="alert">
-      <p>Error: {{state.reason}}</p>
+    <div *ngIf="signinError" class="alert">
+      <p>Error: {{signinError}}</p>
     </div>
 
     <p>No account ? Sign up <a [routerLink]="['/auth/signup']">here</a></p>

--- a/src/frontend/src/app/auth/signin/signin.component.ts
+++ b/src/frontend/src/app/auth/signin/signin.component.ts
@@ -10,7 +10,7 @@ import { SigninService } from './signin.service';
   styleUrls: ['./signin.component.css'],
 })
 export class SignInComponent implements OnInit {
-  state = { failure: false, reason: '' };
+  signinError?: string;
 
   signInForm = this.formBuilder.nonNullable.group({
     username: ['', Validators.required],
@@ -23,11 +23,7 @@ export class SignInComponent implements OnInit {
     private service: SigninService,
     private signOut: SignoutService,
   ) {
-    const error = window.history.state['error'];
-    if (error) {
-      this.state.failure = true;
-      this.state.reason = error;
-    }
+    this.service.siginError$.subscribe((err) => (this.signinError = err));
   }
 
   ngOnInit(): void {
@@ -35,10 +31,7 @@ export class SignInComponent implements OnInit {
   }
 
   localSignIn() {
-    this.service.signIn(
-      { type: 'local', form: this.signInForm.getRawValue() },
-      this.state,
-    );
+    this.service.signIn({ type: 'local', form: this.signInForm.getRawValue() });
   }
 
   oAuthSignIn() {

--- a/src/frontend/src/app/auth/signin/signin.component.ts
+++ b/src/frontend/src/app/auth/signin/signin.component.ts
@@ -23,7 +23,11 @@ export class SignInComponent implements OnInit {
     private service: SigninService,
     private signOut: SignoutService,
   ) {
-    this.service.siginError$.subscribe((err) => (this.signinError = err));
+    // error state is used by JwtService if refresh fails
+    if (window.history.state['error'])
+      this.signinError = window.history.state['error'];
+    // otherwise errors are emitted within SigninService
+    this.service.signinError$.subscribe((err) => (this.signinError = err));
   }
 
   ngOnInit(): void {

--- a/src/frontend/src/app/auth/signin/signin.service.ts
+++ b/src/frontend/src/app/auth/signin/signin.service.ts
@@ -17,7 +17,7 @@ export class SigninService {
   private readonly local_signin_url = `${environment.backend}/auth/local/signin`;
   private readonly oauth_signin_url = `${environment.backend}/auth/oauth42/signin`;
   private _signinError = new Subject<string>();
-  siginError$ = this._signinError.asObservable();
+  signinError$ = this._signinError.asObservable();
   private signinEvent: EventEmitter<boolean>;
 
   constructor(

--- a/src/frontend/src/app/auth/signup/select/select.component.html
+++ b/src/frontend/src/app/auth/signup/select/select.component.html
@@ -20,8 +20,5 @@
         </svg>
       </button>
     </div>
-
-    <!-- Sign-in redirect  -->
-    <p>Already have an account ? Sign in <a [routerLink]="['/auth/signin']">here</a></p>
   </div>
 </div>

--- a/src/frontend/src/app/auth/signup/signup.component.css
+++ b/src/frontend/src/app/auth/signup/signup.component.css
@@ -160,7 +160,7 @@ p {
   display: flex;
   width: 100%;
   padding: 8px;
-  border-radius: 0px 0px 3px 3px;
+  border-radius: 3px;
   padding-left: 12px;
   padding-right: 12px;
 }

--- a/src/frontend/src/app/auth/signup/signup.component.html
+++ b/src/frontend/src/app/auth/signup/signup.component.html
@@ -14,7 +14,7 @@
       <div class="field-register">
         <label>Choose your username:</label>
         <input formControlName="username" placeholder="Username" name="username" autocomplete="username">
-        <div *ngIf="username.invalid && (username.dirty || username.touched)" class="alert">
+        <div *ngIf="username.invalid && (username.dirty || username.touched || username.value)" class="alert">
           <div *ngIf="username.errors?.['required']"> Username is required. </div>
           <div *ngIf="username.errors?.['maxlength']"> Username too long (42 char max). </div>
           <div *ngIf="username.errors?.['isAvailable']"> Username `{{username.value}}` is unavailable. </div>
@@ -51,5 +51,12 @@
 
     </form>
 
+    <div *ngIf="signupError" class="alert">
+      <p>Error: {{signupError}}</p>
+    </div>
+
     <app-select *ngIf="!signUpType"></app-select>
+
+    <!-- Sign-in redirect  -->
+    <p>Already have an account ? Sign in <a [routerLink]="['/auth/signin']">here</a></p>
   </div>

--- a/src/frontend/src/app/auth/signup/signup.component.ts
+++ b/src/frontend/src/app/auth/signup/signup.component.ts
@@ -26,6 +26,7 @@ export class SignUpComponent implements OnInit {
   image_url = assets.defaultAvatar;
   // Oauth specific
   token?: string;
+  signupError = '';
   oAuthUser?: OAuthUserDto;
   private readonly _requirements = {
     username: [
@@ -94,9 +95,11 @@ export class SignUpComponent implements OnInit {
         this.oAuthUser = this.oauth.getOAuthUserData(this.token);
         this.registerForm.patchValue({ username: this.oAuthUser.login });
         this.image_url = this.oAuthUser.image_url;
+        this.signupError = '';
       } else if (params['type'] == 'local') {
         this.signUpType = 'local';
         this.registerForm = this.localForm;
+        this.signupError = '';
       }
     });
   }
@@ -108,12 +111,17 @@ export class SignUpComponent implements OnInit {
         this.registerForm?.value,
         this.token,
       );
-      signUpStatus$.subscribe((response) => {
-        this.signin.signInSuccess(
-          response.tokens.access,
-          response.tokens.refresh,
-        );
-        this.avatar.backendUpload();
+      signUpStatus$.subscribe({
+        next: (response) => {
+          this.signin.signInSuccess(
+            response.tokens.access,
+            response.tokens.refresh,
+          );
+          this.avatar.backendUpload();
+        },
+        error: () => {
+          this.signupError = 'Signup failed.';
+        },
       });
     }
   }

--- a/src/frontend/src/app/auth/two-factors/otp-page/otp-page.component.ts
+++ b/src/frontend/src/app/auth/two-factors/otp-page/otp-page.component.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { environment } from 'src/environments/environment';
 import { AuthenticatorSigninDto, SignInSuccessDto } from '../../signin/dto';
 import { SigninService } from '../../signin/signin.service';
@@ -13,15 +12,12 @@ import { OtpCode } from '../dto';
 })
 export class OtpPageComponent implements OnInit {
   partialSigninToken?: string;
-  constructor(
-    private router: Router,
-    private http: HttpClient,
-    private signinService: SigninService,
-  ) {}
+  constructor(private http: HttpClient, private signinService: SigninService) {}
 
   ngOnInit(): void {
     this.partialSigninToken = window.history.state['partialSigninToken'];
-    if (!this.partialSigninToken) this.router.navigate(['/auth/signin']);
+    if (!this.partialSigninToken)
+      this.signinService.signInFailure('2FA interrupted');
   }
 
   signin(otp: OtpCode) {
@@ -42,9 +38,7 @@ export class OtpPageComponent implements OnInit {
               response.tokens.refresh,
             ),
           error: (err: HttpErrorResponse) => {
-            this.router.navigate(['/auth/signin'], {
-              state: { error: err.error.message },
-            });
+            this.signinService.signInFailure(err);
           },
         });
     }


### PR DESCRIPTION
### Tasks
- [x] signup: oauth redirect to signin page with relevant error message if 42's account already used by an account
- [x] signin: oauth proper error message if user does not exist yet and redirect to signup page
- [x] user should sign-out if the refresh token is invalid (or if refresh operation fails), then redirect to signin and display relevant error
- [x] Add a guard to redirect HomeComponent to the signin page if not authenticated

Related to #50 
Closes #70 
Closes #102 
Closes #121 
